### PR TITLE
add/react-media-recorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-media-recorder": "^1.4.0",
     "react-scripts": "4.0.3",
     "react-voice-recorder": "^2.0.9",
     "styled-components": "^5.2.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,24 @@
-import React from 'react';
-import styled from 'styled-components';
-import Recording from './Recording';
+import { useReactMediaRecorder } from 'react-media-recorder';
 
-export default function App() {
+const RecordView = () => {
+  const { status, startRecording, stopRecording, mediaBlobUrl } =
+    useReactMediaRecorder({ audio: true });
+
+  const showType = async () => {
+    console.log(mediaBlobUrl);
+    let blob = await fetch(mediaBlobUrl).then((r) => r.blob());
+    console.log(blob);
+  };
+
   return (
-    <>
-      <Container>
-        <Recording />
-      </Container>
-    </>
+    <div>
+      <p>{status}</p>
+      <button onClick={startRecording}>Start Recording</button>
+      <button onClick={stopRecording}>Stop Recording</button>
+      <button onClick={showType}>audio 확인하기</button>
+      <audio src={mediaBlobUrl} controls autoPlay loop />
+    </div>
   );
-}
+};
 
-const Container = styled.div``;
+export default RecordView;

--- a/src/Recording.js
+++ b/src/Recording.js
@@ -50,7 +50,10 @@ export default function Recording() {
         title={'New recording'}
         showUIAudio
         audioURL={audioDetails.url}
-        {...{ handleAudioStop, handleAudioUpload, handleReset }}
+        handleAudioStop={handleAudioStop}
+        handleAudioUpload={handleAudioUpload}
+        handleReset={handleReset}
+        mimeTypeToUseWhenRecording={`audio/webm`}
       />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9073,6 +9073,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
+react-media-recorder@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-media-recorder/-/react-media-recorder-1.4.0.tgz#e72d366bd87157d634949bdc42300027c78a7aa7"
+  integrity sha512-3lc2LsS6TUG03tmbVd9Fnh7l1+YtbGy5Z+CYQA8zkJuGdroarLXxFExPXu0RqLFbomedD+Axp3pKuNrfIBmHtw==
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"


### PR DESCRIPTION
출처 : https://github.com/0x006F/react-media-recorder#readme

- hooks사용 + 사이트에가면 여러옵션들 존재
- 녹음하면 mediaBlobUrl에 저장됨
- mediaBlobUrl를 blob(type : wav)로 변형해서 사용가능 